### PR TITLE
removes Strings from Enums into Constants.

### DIFF
--- a/sim/Constants.java
+++ b/sim/Constants.java
@@ -7,40 +7,20 @@ public class Constants {
 	public static final double SECONDS_IN_MINUTE = 60.0;
 	public static final double START_SPEED = (FEET_IN_A_MILE * AVERAGE_SPEED_IN_MILES) / (MINUTES_IN_HOUR * SECONDS_IN_MINUTE) ; // 55 miles per hour = 290400 feet per hour = 4840 feet per minute = ~80 feet per second
 	public static final double THOUSAND_METERS_IN_FEET = 3280.84; // Distance between lights
-	public static final String RED = "Red";
-	public static final String YELLOW = "Yellow";
-	public static final String GREEN = "Green";
+	public static final String RED = "RED";
+	public static final String YELLOW = "YELLOW";
+	public static final String GREEN = "GREEN";
+	public static final String START = "START";
+	public static final String PAUSE = "PAUSE";
+	public static final String STOP = "STOP";
+	public static final String INIT = "INIT";
+	public static final String CONTINUE = "CONTINUE";
 
 	public enum TrafficLightColor {
-		RED, YELLOW, GREEN;
-		
-		public static String toString(TrafficLightColor tlc) {
-			switch (tlc) {
-			case RED:
-				return "Red";
-			case YELLOW:
-				return "Yellow";
-			case GREEN:
-				return "Green";
-			}
-			return null;
-		}
-	
+		RED, YELLOW, GREEN;	
 	}
 	
 	public enum SimulationMode {
-		PAUSE("pause"), START("start"), STOP("stop"), INIT("init"), CONTINUE("continue");
-		
-		private String value;
-		
-		private SimulationMode(String value) {
-			this.value = value;
-		}
-
-		public String getValue() {
-			return value;
-		}
-		
+		PAUSE, START, STOP, INIT, CONTINUE;		
 	}
-
 }

--- a/sim/Controller.java
+++ b/sim/Controller.java
@@ -72,22 +72,22 @@ public class Controller implements ActionListener, ChangeListener {
 
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		if (e.getSource() == view.getButton(Constants.SimulationMode.START.getValue())) {
+		if (e.getSource() == view.getButton(Constants.SimulationMode.START.toString())) {
 			System.out.println("A button press is being responded to...");
 			model.startMode();
 		}
 
-		else if (e.getSource() == view.getButton(Constants.SimulationMode.STOP.getValue())) {
+		else if (e.getSource() == view.getButton(Constants.SimulationMode.STOP.toString())) {
 			System.out.println("A stop button was pressed...");
 			model.stopMode();
 		}
 
-		else if (e.getSource() == view.getButton(Constants.SimulationMode.CONTINUE.getValue())) {
+		else if (e.getSource() == view.getButton(Constants.SimulationMode.CONTINUE.toString())) {
 			System.out.println("A continue button was pressed...");
 			model.continueMode();
 		}
 
-		else if (e.getSource() == view.getButton(Constants.SimulationMode.PAUSE.getValue())) {
+		else if (e.getSource() == view.getButton(Constants.SimulationMode.PAUSE.toString())) {
 			System.out.println("A pause button was pressed...");
 			model.pauseMode();
 		}

--- a/sim/Model.java
+++ b/sim/Model.java
@@ -143,17 +143,17 @@ public class Model {
 	
 	public String getTrafficLightOneStatus() {
 		TrafficLightColor tlc = lightOne.getColor();
-		return TrafficLightColor.toString(tlc);
+		return tlc.toString();
 	}
 	
 	public String getTrafficLightTwoStatus() {
 		TrafficLightColor tlc = lightTwo.getColor();
-		return TrafficLightColor.toString(tlc);
+		return tlc.toString();
 	}
 	
 	public String getTrafficLightThreeStatus() {
 		TrafficLightColor tlc = lightThree.getColor();
-		return TrafficLightColor.toString(tlc);
+		return tlc.toString();
 	}
 	
 	public String getCarOnePosition() {

--- a/sim/View.java
+++ b/sim/View.java
@@ -90,16 +90,15 @@ public class View implements Runnable {
 		lightsSlider.addChangeListener(listener);;
 	  }
 
-	//accessor method - returns selected button
 	public JButton getButton(String name) {
 		switch(name) {
-		case "start":
+		case Constants.START:
 			return start;
-		case "stop":
+		case Constants.STOP:
 			return stop;
-		case "pause":
+		case Constants.PAUSE:
 			return pause;
-		case "continueButton":
+		case Constants.CONTINUE:
 			return continueButton;
 		}
 		return null;


### PR DESCRIPTION
Solution 1: This felt like it made more since implementation wise. Enums have name value which may be returned via toString(). Case requires switch values to be constant values (May not use method calls). Will likely use if else cascade to solve same problem instead.